### PR TITLE
fix crash when target package doesn't have a key and sort package keys before output

### DIFF
--- a/src/generateInheritedPackageJson.ts
+++ b/src/generateInheritedPackageJson.ts
@@ -70,7 +70,7 @@ function shouldUpdate(mine: any, theirs: any) {
   let result = false;
 
   for (const [key, value] of Object.entries(theirs)) {
-    if (mine[key] !== value) {
+    if (!mine || mine[key] !== value) {
       result = true;
     }
   }

--- a/src/updateCommand.ts
+++ b/src/updateCommand.ts
@@ -12,7 +12,13 @@ export function updateCommand(cwd: string) {
       const { packageJsonPath, ...output } = info;
 
       const newLine = detectNewline(fs.readFileSync(info.packageJsonPath, 'utf-8')) || os.EOL;
-
+      // Sort dependencies before outputing them like package managers do
+      ['dependencies', 'devDependencies'].map(function(key){
+        if (output[key]) {
+          const keys = Object.keys(output[key]).sort();
+          output[key] = JSON.parse(JSON.stringify(output[key], keys));
+        }
+      });
       fs.writeFileSync(
         info.packageJsonPath,
         JSON.stringify(output, null, 2).replace(/\n/g, newLine) + newLine

--- a/src/updateCommand.ts
+++ b/src/updateCommand.ts
@@ -15,8 +15,10 @@ export function updateCommand(cwd: string) {
       // Sort dependencies before outputing them like package managers do
       ['dependencies', 'devDependencies'].map(function(key){
         if (output[key]) {
-          const keys = Object.keys(output[key]).sort();
-          output[key] = JSON.parse(JSON.stringify(output[key], keys));
+          output[key] = Object.keys(output[key]).sort().reduce(function(newObject, packageName) {
+            newObject[packageName] = output[key][packageName];
+            return newObject;
+          }, {});
         }
       });
       fs.writeFileSync(


### PR DESCRIPTION
This is a great tool. Thanks for putting it together.

I stumbled on two issues while adding it to our system.

I added an inherit which had a devDependencies block to a package that didn't already have devDependencies block which triggered a crash. The first commit fixes that crash.

I also noted that when adding a new inherit the packages were no longer sorted. Adding a package with a package manager like yarn or npm would cause many lines to move because package managers sort these keys before output. Thus I have added sorting for these keys before outputting them to match package manager behavior when potentially adding a new inherit to a package.