### PR TITLE
Creating more useful error message when checking inheritance

### DIFF
--- a/src/generateInheritedPackageJson.ts
+++ b/src/generateInheritedPackageJson.ts
@@ -19,7 +19,7 @@ export function generateInheritedPackageJson(cwd: string) {
         const file = resolveInRepo(pkg, specifier, allPackages);
 
         if (!file) {
-          throw new Error(`${file} does not exist`);
+          throw new Error(`file does not exist. pkg:${pkg}, specifier:${specifier}`);
         }
 
         const inheritInfo = JSON.parse(fs.readFileSync(file, "utf-8"));


### PR DESCRIPTION
${file} is not defined in this block. a more useful error message is probably one with package name and specifier.